### PR TITLE
Ward/last

### DIFF
--- a/client/chart.coffee
+++ b/client/chart.coffee
@@ -10,10 +10,10 @@ formatTime = (time) ->
   mi = (if d.getMinutes() < 10 then "0" else "") + d.getMinutes()
   "#{h}:#{mi} #{am}<br>#{d.getDate()} #{mo} #{d.getFullYear()}"
 
-display = (div, data) ->
+display = ($item, data) ->
   [time, sample] = data
-  div.find('p:first').text sample.toFixed(1)
-  div.find('p:last').html formatTime(time)
+  $item.find('p:first').text sample.toFixed(1)
+  $item.find('p:last').html formatTime(time)
 
 findData = (item, thumb) ->
   for data in item.data
@@ -21,25 +21,27 @@ findData = (item, thumb) ->
   null
 
 window.plugins.chart =
-  emit: (div, item) ->
+
+  emit: ($item, item) ->
     [time, sample] = last(item.data)
-    chartElement = $('<p />').addClass('readout').appendTo(div).text(sample)
-    captionElement = $('<p />').html(wiki.resolveLinks(item.caption)).appendTo(div)
-  bind: (div, item) ->
+    chartElement = $('<p />').addClass('readout').appendTo($item).text(sample)
+    captionElement = $('<p />').html(wiki.resolveLinks(item.caption)).appendTo($item)
+
+  bind: ($item, item) ->
 
     lastThumb = null
 
-    div.find('p:first')
+    $item.find('p:first')
       .mousemove (e) ->
         return unless (data = item.data[Math.floor(item.data.length * e.offsetX / e.target.offsetWidth)])?
         [time, sample] = data
         return if time == lastThumb || null == (lastThumb = time)
-        display div, data
-        div.trigger('thumb', +time)
+        display $item, data
+        $item.trigger('thumb', +time)
       .dblclick ->
         wiki.dialog "JSON for #{item.caption}", $('<pre/>').text(JSON.stringify(item.data, null, 2))
 
     $('.main').on 'thumb', (evt, thumb) ->
       if thumb != lastThumb and (data = findData item, thumb)
         lastThumb = thumb
-        display div, data
+        display $item, data


### PR DESCRIPTION
This rarely used plugin relied on a patch to array to return its last value. We now accept that we don't have that functionality and define it ourselves.

This regression motivated the retry functionality of https://github.com/fedwiki/wiki-client/pull/34

We also adopt the "$item" convention in place of the less descriptive "dev".
