### PR TITLE
Fix some long standing issues

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,8 @@
 module.exports = function (grunt) {
+  grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-coffee');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-git-authors');
 
   grunt.initConfig({
 
@@ -11,44 +13,30 @@ module.exports = function (grunt) {
       ]
     },
 
-    coffee: {
-      client: {
-        expand: true,
+    browserify: {
+      packageClient: {
+        src: ['client/chart.coffee'],
+        dest: 'client/chart.js',
         options: {
-          sourceMap: true
-        },
-        src: ['client/*.coffee'],
-        ext: '.js'
+          transform: ['coffeeify'],
+          browserifyOptions: {
+            extensions: ".coffee"
+          }
+        }
       }
     },
 
     watch: {
       all: {
         files: ['client/*.coffee'],
-        tasks: ['coffee']
+        tasks: ['browserify']
       }
     }
   });
 
-  grunt.registerTask( "update-authors", function () {
-    var getAuthors = require("grunt-git-authors"),
-    done = this.async();
 
-    getAuthors({
-      priorAuthors: grunt.config( "authors.prior")
-      }, function(error, authors) {
-        if (error) {
-          grunt.log.error(error);
-          return done(false);
-        }
 
-        grunt.file.write("AUTHORS.txt",
-          "Authors ordered by first contribution\n\n" +
-          authors.join("\n") + "\n");
-      });
-  });
-
-  grunt.registerTask('build', ['coffee']);
+  grunt.registerTask('build', ['browserify']);
   grunt.registerTask('default', ['build']);
 
 };

--- a/client/chart.coffee
+++ b/client/chart.coffee
@@ -5,6 +5,8 @@
  * https://github.com/fedwiki/wiki-plugin-chart/blob/master/LICENSE.txt
 ###
 
+sanitize = require 'sanitize-caja'
+
 last = (array) ->
   array[array.length-1]
 
@@ -32,7 +34,7 @@ window.plugins.chart =
   emit: ($item, item) ->
     [time, sample] = last(item.data)
     chartElement = $('<p />').addClass('readout').appendTo($item).text(sample)
-    captionElement = $('<p />').html(wiki.resolveLinks(item.caption)).appendTo($item)
+    captionElement = $('<p />').html(wiki.resolveLinks(item.caption, sanitize)).appendTo($item)
 
   bind: ($item, item) ->
 

--- a/client/chart.coffee
+++ b/client/chart.coffee
@@ -42,6 +42,8 @@ window.plugins.chart =
 
     $item.find('p:first')
       .mousemove (e) ->
+        if typeof e.offsetX == "undefined"
+          e.offsetX = e.pageX - $(e.target).offset().left
         return unless (data = item.data[Math.floor(item.data.length * e.offsetX / e.target.offsetWidth)])?
         [time, sample] = data
         return if time == lastThumb || null == (lastThumb = time)

--- a/package.json
+++ b/package.json
@@ -28,17 +28,15 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "sanitize-caja": "*",
+    "grunt-browserify": "~3",
+    "coffeeify": "~1",
     "grunt": "~0.4",
-    "grunt-contrib-coffee": "~0.12",
+    "grunt-contrib-coffee": "~0.13",
     "grunt-contrib-watch": "~0.6",
-    "grunt-git-authors": "~2"
+    "grunt-git-authors": "~3"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/fedwiki/wiki-plugin-chart/blob/master/LICENSE.txt"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/fedwiki/wiki-plugin-chart.git"
@@ -47,6 +45,6 @@
     "url": "https://github.com/fedwiki/wiki-plugin-chart/issues"
   },
   "engines": {
-    "node": "0.10"
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
Not sure if either of these issues ever got raised as raised, but...

1. As the plugin pages use html in the chart captions, run the caption through the sanitizer rather than escaping, and
2. Apply the fix used in the method plugin to allow the data to be scrubbed over in browsers that don't define offsetX - probably just Firefox.

Build script updated to enable the above, and dependencies updated.